### PR TITLE
Remove yanked gem dependency

### DIFF
--- a/crf.gemspec
+++ b/crf.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec)/})
 
-  spec.add_dependency 'find', '~> 1.3', '>= 1.3.9'
   spec.add_dependency 'colorize', '~> 0.7', '>= 0.7.7'
   spec.add_dependency 'ruby-progressbar', '~> 1.7', '>= 1.7.5'
 

--- a/lib/crf/finder.rb
+++ b/lib/crf/finder.rb
@@ -1,6 +1,5 @@
 require 'crf/repetitions_list'
 require 'digest'
-require 'find'
 require 'ruby-progressbar'
 
 module Crf
@@ -36,7 +35,7 @@ module Crf
 
     def all_files(path)
       paths ||= []
-      Find.find(path) { |p| paths << p unless File.directory?(p) }
+      Dir["#{path.chomp('/')}/*"].each { |p| paths << p unless File.directory?(p) }
       paths
     end
 

--- a/spec/remover_spec.rb
+++ b/spec/remover_spec.rb
@@ -25,11 +25,11 @@ describe 'Crf Remover' do
 
     it 'finds the repetitions and removes them' do
       paths = []
-      Find.find(test_files_directory) { |p| paths << p unless File.directory?(p) }
+      Dir["#{test_files_directory}*"].each { |p| paths << p unless File.directory?(p) }
       expect(paths.length).to eq(5)
       Crf::Remover.new(finder.search_repeated_files, logger).remove
       paths = []
-      Find.find(test_files_directory) { |p| paths << p unless File.directory?(p) }
+      Dir["#{test_files_directory}*"].each { |p| paths << p unless File.directory?(p) }
       expect(paths.length).to eq(4)
       expect(finder.search_repeated_files.empty?).to be_truthy
     end


### PR DESCRIPTION
@alebian 

The find gem was yanked from rubygems. It seems that it was used to
  traverse files in a directory.

Instead, the built in `Dir` method has been used
